### PR TITLE
 Fixed variable @zindex-modal-background is undefined

### DIFF
--- a/vendor/toolkit/twitter/bootstrap/variables.less
+++ b/vendor/toolkit/twitter/bootstrap/variables.less
@@ -7,6 +7,7 @@
 //
 //## Gray and brand colors for use across Bootstrap.
 
+@zindex-modal-background: 0;
 @gray-darker:            lighten(#000, 13.5%); // #222
 @gray-dark:              lighten(#000, 20%);   // #333
 @gray:                   lighten(#000, 33.5%); // #555


### PR DESCRIPTION
Added @zindex-modal-background: 0;  to fix this bug 'variable @zindex-modal-background is undefined'.
This bug happens when I try to run my app for the first time after adding twitter-bootswatch gem and then running these commands: 
rails g bootswatch:install cyborg
rails g bootswatch:import cyborg
rails g bootswatch:layout cyborg