### PR TITLE
Markup is not for horizontal form, removing class to fix padding.

### DIFF
--- a/lib/generators/bootswatch/themed/templates/_form.html.erb
+++ b/lib/generators/bootswatch/themed/templates/_form.html.erb
@@ -1,4 +1,4 @@
-<%%= form_for @<%= resource_name %>, :html => { :class => 'form-horizontal' } do |f| %>
+<%%= form_for @<%= resource_name %> do |f| %>
   <%- columns.each do |column| -%>
   <div class="form-group">
     <%%= f.label :<%= column.name %>, :class => 'control-label' %>

--- a/lib/generators/bootswatch/themed/templates/_form.html.haml
+++ b/lib/generators/bootswatch/themed/templates/_form.html.haml
@@ -1,4 +1,4 @@
-= form_for @<%= resource_name %>, :html => { :class => 'form-horizontal' } do |f|
+= form_for @<%= resource_name %> do |f|
   <%- columns.each do |column| -%>
   .form-group
     = f.label :<%= column.name %>, :class => 'control-label'

--- a/lib/generators/bootswatch/themed/templates/_form.html.slim
+++ b/lib/generators/bootswatch/themed/templates/_form.html.slim
@@ -1,4 +1,4 @@
-= form_for @<%= resource_name %>, :html => { :class => 'form-horizontal' } do |f|
+= form_for @<%= resource_name %> do |f|
   <%- columns.each do |column| -%>
   .form-group
     = f.label :<%= column.name %>, :class => 'control-label'


### PR DESCRIPTION
The form-horizontal breaks padding with current markup, so removing.