### PR TITLE
Upgrade less-rails to fix the deprecation warnings from sprockets v3〜

### DIFF
--- a/twitter-bootswatch-rails.gemspec
+++ b/twitter-bootswatch-rails.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.add_dependency             'railties', '>= 3.1', '< 5.0'
-  s.add_dependency             'less-rails', '~> 2.4'
+  s.add_dependency             'less-rails', '~> 3.0'
   s.add_dependency             'execjs', '~> 2.3', '>= 2.3.0'
 
   s.add_development_dependency 'rails', '>= 3.1', '< 5.0'


### PR DESCRIPTION
When we use twitter-bootswatch-rails (v3.3.4.0) with sprockets (v3.0 or above), sprockets shows warning messages like below:

```
DEPRECATION WARNING: Sprockets method `register_engine` is deprecated.
Please register a mime type using `register_mime_type` then
use `register_compressor` or `register_transformer`.
https://github.com/rails/sprockets/blob/master/guides/extending_sprockets.md#supporting-all-versions-of-sprockets-in-processors
 (called from block in <class:Railtie> at /data/bundle/gems/less-rails-2.8.0lib/less/rails/railtie.rb:15)
DEPRECATION WARNING: You are using the a deprecated processor interface Less::Rails::ImportProcessor.
Please update your processor interface:
https://github.com/rails/sprockets/blob/master/guides/extending_sprockets.md#supporting-all-versions-of-sprockets-in-processors
 (called from block in <class:Railtie> at /data/bundle/gems/less-rails-2.8.0/lib/less/rails/railtie.rb:20)
```

This pr upgrades the version specification for less-rails not to get those warnings .
